### PR TITLE
The Trees are now being colored during find and union operations

### DIFF
--- a/backend/Program.cs
+++ b/backend/Program.cs
@@ -67,7 +67,7 @@ app.MapPost("/api/{ufType}/edges", async (string ufType, EdgeDTO edge, DBContext
     var startNode = await dbContext.Nodes.FindAsync(edge.StartNodeId);
     if (startNode == null)
     {
-        startNode = new Node { Id = edge.StartNodeId, Parent = -1 };
+        startNode = new Node { Id = edge.StartNodeId, Parent = edge.StartNodeId };
         dbContext.Nodes.Add(startNode);
         await dbContext.SaveChangesAsync();
     }
@@ -75,7 +75,7 @@ app.MapPost("/api/{ufType}/edges", async (string ufType, EdgeDTO edge, DBContext
     var endNode = await dbContext.Nodes.FindAsync(edge.EndNodeId);
     if (endNode == null)
     {
-        endNode = new Node { Id = edge.EndNodeId, Parent = -1 };
+        endNode = new Node { Id = edge.EndNodeId, Parent = edge.EndNodeId };
         dbContext.Nodes.Add(endNode);
         await dbContext.SaveChangesAsync();
     }

--- a/backend/infrastructure/Entities/Node.cs
+++ b/backend/infrastructure/Entities/Node.cs
@@ -8,8 +8,8 @@ public class Node
     public required int Id {get; set;}
     public List<Edge>? Edges {get; set;}
     
-    // -1 = root
-    public int Parent {get; set;} = -1; 
+    // parent should be set to itself upon initialization
+    public int Parent {get; set;} 
     
     // used by root nodes to track size of tree
     public int Size { get; set; } = 1;

--- a/backend/infrastructure/Services/PathCompressionUFService.cs
+++ b/backend/infrastructure/Services/PathCompressionUFService.cs
@@ -20,7 +20,7 @@ public class PathCompressionUFService : IUnionFindService
             throw new Exception($"Node {nodeId} not found");
 
         // Base case: this node is its own root
-        if (nodes[nodeId].Parent == -1)
+        if (nodes[nodeId].Parent == nodeId)
             return nodeId;
 
         // Recurse to find root, then point current node directly to it
@@ -70,7 +70,7 @@ public class PathCompressionUFService : IUnionFindService
 
     public async Task<int> CountAsync()
     {
-        return await _db.Nodes.CountAsync(n => n.Parent == -1);
+        return await _db.Nodes.CountAsync(n => n.Parent == n.Id);
     }
 
     public async Task RebuildAsync()
@@ -78,7 +78,7 @@ public class PathCompressionUFService : IUnionFindService
         var allNodes = await _db.Nodes.ToListAsync();
         foreach (var node in allNodes)
         {
-            node.Parent = -1;
+            node.Parent = node.Id;
             node.Size = 1;
         }
         await _db.SaveChangesAsync();

--- a/backend/infrastructure/Services/UnionFindService.cs
+++ b/backend/infrastructure/Services/UnionFindService.cs
@@ -9,13 +9,13 @@ public class UnionFindService : IUnionFindService
         _db = db;
     }
 
-    // Find - walk up parents until we hit a root (Parent == -1)
+    // Find - walk up parents until we hit a root (Parent == Id)
     public async Task<int> FindAsync(int nodeId)
     {
         var node = await _db.Nodes.FindAsync(nodeId)
             ?? throw new Exception($"Node {nodeId} not found");
 
-        if (node.Parent == -1) return node.Id;
+        if (node.Parent == node.Id) return node.Id;
 
         return await FindAsync(node.Parent);
     }
@@ -41,7 +41,7 @@ public class UnionFindService : IUnionFindService
         var allNodes = _db.Nodes.ToList();
         foreach (var node in allNodes)
         {
-            node.Parent = -1;
+            node.Parent = node.Id;
         }
         await _db.SaveChangesAsync();
 

--- a/backend/infrastructure/Services/WeightedUFService.cs
+++ b/backend/infrastructure/Services/WeightedUFService.cs
@@ -12,7 +12,7 @@ public class WeightedUFService : IUnionFindService
         _db = db;
     }
 
-    // Find - walk up parents until we hit a root (Parent == -1)
+    // Find - walk up parents until we hit a root (Parent == Id)
     // Weighted so should be O(log N)
     private int FindRoot(int nodeId, Dictionary<int, Node> nodes)
     {
@@ -21,8 +21,8 @@ public class WeightedUFService : IUnionFindService
 
         int current = nodeId;
 
-        // Walk up to root — root is the node where Parent == -1
-        while (nodes[current].Parent != -1)
+        // Walk up to root — root is the node where Parent == Id
+        while (nodes[current].Parent != current)
             current = nodes[current].Parent;
 
         return current;
@@ -76,7 +76,7 @@ public class WeightedUFService : IUnionFindService
     // Count of distinct components (nodes that are their own root)
     public async Task<int> CountAsync()
     {
-        return await _db.Nodes.CountAsync(n => n.Parent == -1);
+        return await _db.Nodes.CountAsync(n => n.Parent == n.Id);
     }
 
     public async Task RebuildAsync()
@@ -85,7 +85,7 @@ public class WeightedUFService : IUnionFindService
         var allNodes = await _db.Nodes.ToListAsync();
         foreach (var node in allNodes)
         {
-            node.Parent = -1;
+            node.Parent = node.Id;
             node.Size = 1;
         }
         await _db.SaveChangesAsync();

--- a/frontend/src/components/Tree.tsx
+++ b/frontend/src/components/Tree.tsx
@@ -14,7 +14,7 @@ function buildTrees(nodes: NodeDTO[]): Map<number, number[]> {
 
   for (const node of nodes) {
     if (!children.has(node.id)) children.set(node.id, []);
-    if (node.parent !== -1) {
+    if (node.parent !== node.id) {
       if (!children.has(node.parent)) children.set(node.parent, []);
       children.get(node.parent)!.push(node.id);
     }
@@ -47,7 +47,7 @@ function layoutSubtree(
 }
 
 export function Tree({ nodes, background, findNodeIds, findEdgePairs, unionChildId }: Props) {
-  const roots = nodes.filter(n => n.parent === -1);
+  const roots = nodes.filter(n => n.parent === n.id);
   const children = buildTrees(nodes);
 
   return (
@@ -85,7 +85,7 @@ export function Tree({ nodes, background, findNodeIds, findEdgePairs, unionChild
               style={{ background }}
             >
               <g transform={`translate(${offsetX}, ${PAD + 20})`}>
-                {nodes.filter(n => n.parent !== -1).map(n => {
+                {nodes.filter(n => n.parent !== n.id).map(n => {
                   const from = positions.get(n.parent);
                   const to = positions.get(n.id);
                   if (!from || !to) return null;
@@ -98,7 +98,7 @@ export function Tree({ nodes, background, findNodeIds, findEdgePairs, unionChild
                     key={`e-${n.id}`} 
                     x1={from.x} y1={from.y} 
                     x2={to.x} y2={to.y} 
-                    stroke={isUnion ? "#c74444" : isFind ? "#333" : "#aaa"}
+                    stroke={isUnion ? "#c74444" : isFind ? "#f4ea28" : "#aaa"}
                     strokeWidth={isFind ? 5 : isUnion ? 3 : 1.5}
                     style={{ transition: "stroke 0.3s, stroke-width 0.3s" }} 
                     />;
@@ -110,6 +110,8 @@ export function Tree({ nodes, background, findNodeIds, findEdgePairs, unionChild
                   const isRoot = n.id === root.id;
                   const isFind  = findNodeIds?.has(n.id) ?? false;
                   const isUnion = unionChildId === n.id;
+
+                  if (isUnion) { console.log("union line:", n.id, "->", n.parent); }
 
                   return (
                     <g key={n.id} transform={`translate(${pos.x}, ${pos.y})`}>
@@ -126,8 +128,8 @@ export function Tree({ nodes, background, findNodeIds, findEdgePairs, unionChild
                       )}
                       <circle
                         r={18}
-                        fill={isUnion ? "#ffcdd2" : isFind ? "#e8ccdb" : isRoot ? "#f199ca" : "white"}
-                        stroke={ isFind ? "#de9abf" : isRoot ? "#e4278f" : "#de9abf"}
+                        fill={isUnion ? "#ffcdd2" : isFind ? "#f1e75a" : isRoot ? "#f199ca" : "white"}
+                        stroke={ isFind ? "#f5fe7b" : isRoot ? "#e4278f" : "#de9abf"}
                         strokeWidth={isFind || isUnion || isRoot ? 2.5 : 1.5}
                         style={{ transition: "fill 0.3s, stroke 0.3s" }}
                       />

--- a/frontend/src/components/Tree.tsx
+++ b/frontend/src/components/Tree.tsx
@@ -1,9 +1,5 @@
 type NodeDTO = { id: number; parent: number };
 
-type VisualTheme = {
-  background: string;
-}
-
 type Props = {
   nodes: NodeDTO[];
   background: string;
@@ -35,7 +31,6 @@ function layoutSubtree(
   const NODE_SPACING = 50;
 
   const kids = children.get(nodeId) ?? [];
-  const startX = xOffset.val;
 
   for (const child of kids) {
     layoutSubtree(child, children, depth + 1, xOffset, positions);
@@ -54,16 +49,16 @@ export function Tree({ nodes, background }: Props) {
 
   return (
     <div
-        style={{
-          width: 870,
-          height: 500,
-          padding: "4px 12px 12px 12px",
-          maxHeight: "600px",
-          overflow: "auto",
-          display: "flex",        
-          flexWrap: "wrap",
-        }}
-      >
+      style={{
+        width: 870,
+        height: 500,
+        padding: "4px 12px 12px 12px",
+        maxHeight: "600px",
+        overflow: "auto",
+        display: "flex",
+        flexWrap: "wrap",
+      }}
+    >
       {roots.length === 0 && <p style={{ color: "#888" }}>Connect nodes to see trees.</p>}
       {roots.map(root => {
         const positions = new Map<number, { x: number; y: number }>();
@@ -80,12 +75,12 @@ export function Tree({ nodes, background }: Props) {
         return (
           <div key={root.id} style={{ marginBottom: 24 }}>
             <svg
-                width="100%"
-                height={svgH + 20}
-                viewBox={`0 0 ${svgW} ${svgH}`}
-                preserveAspectRatio="xMinYMin meet"
-                style={{ background }}
-              >
+              width="100%"
+              height={svgH + 20}
+              viewBox={`0 0 ${svgW} ${svgH}`}
+              preserveAspectRatio="xMinYMin meet"
+              style={{ background }}
+            >
               <g transform={`translate(${offsetX}, ${PAD + 20})`}>
                 {nodes.filter(n => n.parent !== -1).map(n => {
                   const from = positions.get(n.parent);
@@ -94,25 +89,34 @@ export function Tree({ nodes, background }: Props) {
                   return <line key={`e-${n.id}`} x1={from.x} y1={from.y} x2={to.x} y2={to.y} stroke="#aaa" strokeWidth={1.5} />;
                 })}
                 {nodes.map(n => {
-          const pos = positions.get(n.id);
-          if (!pos) return null;
-          const isRoot = n.id === root.id;
-          return (
-            <g key={n.id} transform={`translate(${pos.x}, ${pos.y})`}>
-              {isRoot && (
-                <text
-                  textAnchor="middle"
-                  dominantBaseline="auto"
-                  fontSize={11}
-                  fill="#555"
-                  y={-35}
-                >
-                  Root: <tspan fontWeight="bold">{n.id}</tspan>
-                </text>
-              )}
-              <circle r={18} fill={isRoot ? "#f199ca" : "white"} stroke={isRoot ? "#e4278f" : "#de9abf"} strokeWidth={isRoot ? 2.5 : 1.5} />
-              <text textAnchor="middle" dominantBaseline="middle" fontSize={12} style={{ userSelect: "none" }}>{n.id}</text>
-              </g>
+                  const pos = positions.get(n.id);
+                  if (!pos) return null;
+                  const isRoot = n.id === root.id;
+                  return (
+                    <g key={n.id} transform={`translate(${pos.x}, ${pos.y})`}>
+                      {isRoot && (
+                        <text
+                          textAnchor="middle"
+                          dominantBaseline="auto"
+                          fontSize={11}
+                          fill="#555"
+                          y={-35}
+                        >
+                          Root: <tspan fontWeight="bold">{n.id}</tspan>
+                        </text>
+                      )}
+                      <circle
+                        r={18}
+                        fill={n.id === root.id ? "#f199ca" : "white"}
+                        stroke={n.id === root.id ? "#e4278f" : "#de9abf"}
+                        strokeWidth={n.id === root.id ? 2.5 : 1.5}
+                      />
+                      <text
+                        textAnchor="middle"
+                        dominantBaseline="middle"
+                        fontSize={12} style={{ userSelect: "none" }}>{n.id}
+                      </text>
+                    </g>
                   );
                 })}
               </g>

--- a/frontend/src/components/Tree.tsx
+++ b/frontend/src/components/Tree.tsx
@@ -3,6 +3,9 @@ type NodeDTO = { id: number; parent: number };
 type Props = {
   nodes: NodeDTO[];
   background: string;
+  findNodeIds?: Set<number>;
+  findEdgePairs?: Set<string>;
+  unionChildId?: number | null;
 };
 
 function buildTrees(nodes: NodeDTO[]): Map<number, number[]> {
@@ -43,7 +46,7 @@ function layoutSubtree(
   positions.set(nodeId, { x: (kids.length === 0 ? xOffset.val - 1 : x) * NODE_SPACING, y: depth * LEVEL_H });
 }
 
-export function Tree({ nodes, background }: Props) {
+export function Tree({ nodes, background, findNodeIds, findEdgePairs, unionChildId }: Props) {
   const roots = nodes.filter(n => n.parent === -1);
   const children = buildTrees(nodes);
 
@@ -86,12 +89,28 @@ export function Tree({ nodes, background }: Props) {
                   const from = positions.get(n.parent);
                   const to = positions.get(n.id);
                   if (!from || !to) return null;
-                  return <line key={`e-${n.id}`} x1={from.x} y1={from.y} x2={to.x} y2={to.y} stroke="#aaa" strokeWidth={1.5} />;
+
+                  const pairKey = `${n.id}-${n.parent}`;
+                  const isFind  = findEdgePairs?.has(pairKey) ?? false;
+                  const isUnion = unionChildId === n.id;
+                  
+                  return <line 
+                    key={`e-${n.id}`} 
+                    x1={from.x} y1={from.y} 
+                    x2={to.x} y2={to.y} 
+                    stroke={isUnion ? "#c74444" : isFind ? "#333" : "#aaa"}
+                    strokeWidth={isFind ? 5 : isUnion ? 3 : 1.5}
+                    style={{ transition: "stroke 0.3s, stroke-width 0.3s" }} 
+                    />;
                 })}
                 {nodes.map(n => {
                   const pos = positions.get(n.id);
                   if (!pos) return null;
+
                   const isRoot = n.id === root.id;
+                  const isFind  = findNodeIds?.has(n.id) ?? false;
+                  const isUnion = unionChildId === n.id;
+
                   return (
                     <g key={n.id} transform={`translate(${pos.x}, ${pos.y})`}>
                       {isRoot && (
@@ -107,9 +126,10 @@ export function Tree({ nodes, background }: Props) {
                       )}
                       <circle
                         r={18}
-                        fill={n.id === root.id ? "#f199ca" : "white"}
-                        stroke={n.id === root.id ? "#e4278f" : "#de9abf"}
-                        strokeWidth={n.id === root.id ? 2.5 : 1.5}
+                        fill={isUnion ? "#ffcdd2" : isFind ? "#e8ccdb" : isRoot ? "#f199ca" : "white"}
+                        stroke={ isFind ? "#de9abf" : isRoot ? "#e4278f" : "#de9abf"}
+                        strokeWidth={isFind || isUnion || isRoot ? 2.5 : 1.5}
+                        style={{ transition: "fill 0.3s, stroke 0.3s" }}
                       />
                       <text
                         textAnchor="middle"

--- a/frontend/src/pages/UFBuilderPage.tsx
+++ b/frontend/src/pages/UFBuilderPage.tsx
@@ -273,9 +273,13 @@ function UFBuilderPage() {
     const edgePairs = new Set<string>();
     for (const path of [pathA, pathB]) {
       for (let i = 0; i < path.length - 1; i++) {
-        edgePairs.add(`${path[i + 1]}-${path[i]}`);
+        edgePairs.add(`${path[i]}-${path[i + 1]}`);
       }
     }
+
+    console.log("pathA:", pathA);
+    console.log("pathB:", pathB);
+    console.log("edgePairs:", [...edgePairs]);
 
     setFindNodeIds(nodeIds);
     setFindEdgePairs(edgePairs);

--- a/frontend/src/pages/UFBuilderPage.tsx
+++ b/frontend/src/pages/UFBuilderPage.tsx
@@ -64,7 +64,7 @@ function getPathToRoot(startId: number, ufNodes: NodeDTO[]): number[] {
     visited.add(current);
     path.push(current);
     const dto = ufNodes.find(n => n.id === current);
-    if (!dto || dto.parent === current || dto.parent === -1) break;
+    if (!dto || dto.parent === current) break;
     current = dto.parent;
   }
   return path;
@@ -204,6 +204,11 @@ function UFBuilderPage() {
 
     try {
       const preUnionNodes = ufNodes.map(n => ({ ...n }));
+
+      if (!preUnionNodes.find(n => n.id === start.id))
+        preUnionNodes.push({ id: start.id, parent: start.id });
+      if (!preUnionNodes.find(n => n.id === node.id))
+        preUnionNodes.push({ id: node.id, parent: node.id });
 
       const { edgeId: dbEdgeId, updatedNodes } = await createEdgeInDb(start.id, node.id);
       setUfNodes(updatedNodes);

--- a/frontend/src/pages/UFBuilderPage.tsx
+++ b/frontend/src/pages/UFBuilderPage.tsx
@@ -49,7 +49,7 @@ function getAdjacentNodes(nodes: GraphNode[][], row: number, col: number) {
     if (col < cols - 1) { adjacent.push({ node: nodes[row][col + 1]}); }
 
     for(var element of adjacent){
-      console.log("neighbour ids: " + element.node.id);
+      console.log("neighbor ids: " + element.node.id);
       console.log("node row: "+ element.node.row + " node col: " + element.node.col);
     }
     return adjacent;
@@ -64,7 +64,7 @@ function getPathToRoot(startId: number, ufNodes: NodeDTO[]): number[] {
     visited.add(current);
     path.push(current);
     const dto = ufNodes.find(n => n.id === current);
-    if (!dto || dto.parent === current) break;
+    if (!dto || dto.parent === current || dto.parent === -1) break;
     current = dto.parent;
   }
   return path;
@@ -163,17 +163,17 @@ function UFBuilderPage() {
       setSourceNodeId(node.id);
       setSelectedId(node.id);
 
-      const neighbours = getAdjacentNodes(nodes, node.row, node.col)
+      const neighbors = getAdjacentNodes(nodes, node.row, node.col)
         .map(x => x.node)
-        .filter(neighbour =>
+        .filter(neighbor =>
           !edges.some(
             e =>
-              (e.startNode.id === node.id && e.endNode.id === neighbour.id) ||
-              (e.startNode.id === neighbour.id && e.endNode.id === node.id)
+              (e.startNode.id === node.id && e.endNode.id === neighbor.id) ||
+              (e.startNode.id === neighbor.id && e.endNode.id === node.id)
           )
         );
 
-      setAdjacentNodes(neighbours);
+      setAdjacentNodes(neighbors);
       return;
     }
   
@@ -203,7 +203,7 @@ function UFBuilderPage() {
     setAdjacentNodes([]);
 
     try {
-      const preUnionNodes = [...ufNodes];
+      const preUnionNodes = ufNodes.map(n => ({ ...n }));
 
       const { edgeId: dbEdgeId, updatedNodes } = await createEdgeInDb(start.id, node.id);
       setUfNodes(updatedNodes);

--- a/frontend/src/pages/UFBuilderPage.tsx
+++ b/frontend/src/pages/UFBuilderPage.tsx
@@ -55,6 +55,21 @@ function getAdjacentNodes(nodes: GraphNode[][], row: number, col: number) {
     return adjacent;
 }
 
+function getPathToRoot(startId: number, ufNodes: NodeDTO[]): number[] {
+  const path: number[] = [];
+  let current = startId;
+  const visited = new Set<number>();
+  while (true) {
+    if (visited.has(current)) break;
+    visited.add(current);
+    path.push(current);
+    const dto = ufNodes.find(n => n.id === current);
+    if (!dto || dto.parent === current) break;
+    current = dto.parent;
+  }
+  return path;
+}
+
 function UFBuilderPage() {
   const navigate = useNavigate();
 
@@ -86,6 +101,9 @@ function UFBuilderPage() {
     );
   const [showDismissible, setShowDismissible] = useState(false);
   const [redoStack, setRedoStack] = useState<GraphEdge[]>([]);
+  const [findNodeIds, setFindNodeIds] = useState<Set<number>>(new Set());
+  const [findEdgePairs, setFindEdgePairs] = useState<Set<string>>(new Set());
+  const [unionChildId, setUnionChildId] = useState<number | null>(null);
 
   useEffect(() => {
     fetch(`${BASE}/${UFType}/nodes`)
@@ -94,7 +112,7 @@ function UFBuilderPage() {
       .catch(err => console.error("Failed to fetch nodes:", err));
   }, [UFType]);
 
-  const createEdgeInDb = async (startNodeId: number, endNodeId: number): Promise<number> => {
+  const createEdgeInDb = async (startNodeId: number, endNodeId: number): Promise<{ edgeId: number; updatedNodes: NodeDTO[] }> => {
     const res = await fetch(`${BASE}/${UFType}/edges`, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
@@ -108,8 +126,7 @@ function UFBuilderPage() {
 
     // returns flat node list and feeds it into ufNodes
     const { edgeId, nodes: updatedNodes } = await res.json();
-    setUfNodes(updatedNodes);
-    return edgeId;
+    return { edgeId, updatedNodes }
   };
 
   const deleteEdgeInDb = async (edgeId: number) => {
@@ -140,67 +157,65 @@ function UFBuilderPage() {
 
   const onNodeClick = async (node: GraphNode) => {
 
-  if (sourceNodeId === null && mode === "create") {
-  setSourceNodeId(node.id);
-  setSelectedId(node.id);
+    setUnionChildId(null);
 
-  const neighbours = getAdjacentNodes(nodes, node.row, node.col)
-    .map(x => x.node)
-    .filter(neighbour =>
-      !edges.some(
-        e =>
-          (e.startNode.id === node.id && e.endNode.id === neighbour.id) ||
-          (e.startNode.id === neighbour.id && e.endNode.id === node.id)
-      )
-    );
+    if (sourceNodeId === null && mode === "create") {
+      setSourceNodeId(node.id);
+      setSelectedId(node.id);
 
-  setAdjacentNodes(neighbours);
-  return;
-}
+      const neighbours = getAdjacentNodes(nodes, node.row, node.col)
+        .map(x => x.node)
+        .filter(neighbour =>
+          !edges.some(
+            e =>
+              (e.startNode.id === node.id && e.endNode.id === neighbour.id) ||
+              (e.startNode.id === neighbour.id && e.endNode.id === node.id)
+          )
+        );
 
+      setAdjacentNodes(neighbours);
+      return;
+    }
   
+    if (sourceNodeId === node.id && mode == "create") {
+      // Clicking the same node twice -> reset
+      setSourceNodeId(null); //for setting edges
+      setSelectedId(null); //for visibility
+      setAdjacentNodes([]);
+      return;
+    }
 
-  if (sourceNodeId === node.id && mode == "create") {
-    // Clicking the same node twice -> reset
-    setSourceNodeId(null); //for setting edges
-    setSelectedId(null); //for visibility
-    setAdjacentNodes([]);
-    return;
-  }
+    const flatNodes = nodes.flat();
 
-  const flatNodes = nodes.flat();
+    const start = flatNodes.find(n => n.id === sourceNodeId);
 
-  const start = flatNodes.find(n => n.id === sourceNodeId);
+    if (!start) return;
 
-  if (!start) return;
+    if (!adjacentIds.includes(node.id)) {
+      setShowDismissible(true);
+      setSourceNodeId(null);
+      setAdjacentNodes([]);
+      return;
+    }
 
-  if (!adjacentIds.includes(node.id)) {
-    setShowDismissible(true);
     setSourceNodeId(null);
+    setSelectedId(null);
     setAdjacentNodes([]);
-    return;
-  }
 
-  
+    try {
+      const preUnionNodes = [...ufNodes];
 
-  setSourceNodeId(null);
-  setSelectedId(null);
-  setAdjacentNodes([]);
+      const { edgeId: dbEdgeId, updatedNodes } = await createEdgeInDb(start.id, node.id);
+      setUfNodes(updatedNodes);
 
-  try {
-    const dbEdgeId = await createEdgeInDb(start.id, node.id);
-    setEdges((prev) => [
-      ...prev,
-      { 
-        id: dbEdgeId, 
-        startNode: start, 
-        endNode: node }
-    ]);
-    setRedoStack([]);  // clear redo stack on new edge
-  } catch (err) {
-    console.error("Failed to create edge in DB:", err);
-  }
-};
+      setEdges(prev => [...prev, { id: dbEdgeId, startNode: start, endNode: node }]);
+      setRedoStack([]);
+
+      animateFindThenUnion(start.id, node.id, preUnionNodes, updatedNodes);
+    } catch (err) {
+      console.error("Failed to create edge in DB:", err);
+    }
+  };
 
   const onClickReset = () => {
     clearDb();
@@ -209,6 +224,9 @@ function UFBuilderPage() {
 
   const removeLatestEdge = async () => {
     if (edges.length === 0) return;
+    setUnionChildId(null);
+    setFindNodeIds(new Set());
+    setFindEdgePairs(new Set());
     const latest = edges[edges.length - 1];
     try {
       await deleteEdgeInDb(latest.id);
@@ -221,14 +239,58 @@ function UFBuilderPage() {
 
   const redoLatestEdge = async () => {
     if (redoStack.length === 0) return;
+    setUnionChildId(null);
     const latest = redoStack[redoStack.length - 1];
     try {
-      const dbEdgeId = await createEdgeInDb(latest.startNode.id, latest.endNode.id);
+      const preUnionNodes = [...ufNodes];
+      const { edgeId: dbEdgeId, updatedNodes } = await createEdgeInDb(latest.startNode.id, latest.endNode.id);
+      setUfNodes(updatedNodes);
       setEdges(prev => [...prev, { ...latest, id: dbEdgeId }]);
       setRedoStack(prev => prev.slice(0, -1));
+      animateFindThenUnion(latest.startNode.id, latest.endNode.id, preUnionNodes, updatedNodes);
     } catch (err) {
       console.error("Failed to redo edge:", err);
     }
+  };
+
+  const animateFindThenUnion = (
+  startId: number,
+  endId: number,
+  preUnionNodes: NodeDTO[],
+  updatedNodes: NodeDTO[]
+  ) => {
+    const pathA = getPathToRoot(startId, preUnionNodes);
+    const pathB = getPathToRoot(endId, preUnionNodes);
+
+    const nodeIds = new Set([...pathA, ...pathB]);
+
+    // encode each parent->child pair as "parentId-childId" for easy lookup in Tree
+    const edgePairs = new Set<string>();
+    for (const path of [pathA, pathB]) {
+      for (let i = 0; i < path.length - 1; i++) {
+        edgePairs.add(`${path[i + 1]}-${path[i]}`);
+      }
+    }
+
+    setFindNodeIds(nodeIds);
+    setFindEdgePairs(edgePairs);
+    setUnionChildId(null);
+
+    setTimeout(() => {
+      setFindNodeIds(new Set());
+      setFindEdgePairs(new Set());
+
+      console.log("pre:", preUnionNodes);
+
+      // find whichever node actually changed its parent — that's the real union child
+      const changedNode = updatedNodes.find(post => {
+        const pre = preUnionNodes.find(n => n.id === post.id);
+        return pre && pre.parent !== post.parent;
+      });
+
+      console.log("changedNode:", changedNode);
+      setUnionChildId(changedNode?.id ?? null);
+    }, 1000);
   };
 
   const headerMap: Record<string, string> = {
@@ -362,7 +424,12 @@ const treeBg = treeBackgroundMap[UFType] ?? "#ffffff";
         >
           <h2 style={{ marginTop: 0, marginBottom: 8, color: "rgba(0, 0, 0, 0.54)" }}>Union-Find Trees</h2>
 
-          <Tree nodes={ufNodes} background={treeBg} />
+          <Tree 
+            nodes={ufNodes} 
+            background={treeBg}
+            findNodeIds={findNodeIds}
+            findEdgePairs={findEdgePairs}
+            unionChildId={unionChildId} />
         </div>
       </div>
       </div>


### PR DESCRIPTION
I had to make some quite big changes and a migrations, so some of the logic is changed. 

Before running,  please do a **dotnet ef database update** and ensure the database is deleted

- A node parent will now be initialized to itself. This is easer for us and more correct according to theory
- Please come with feedback to the colors, I tried to pick some that are noticable